### PR TITLE
Fix/parameterised query

### DIFF
--- a/Tina4/PostgresqlQuery.php
+++ b/Tina4/PostgresqlQuery.php
@@ -23,10 +23,10 @@ class PostgresqlQuery extends DataConnection implements DataBaseQuery
     final public function query($sql, int $noOfRecords = 10, int $offSet = 0, array $fieldMapping = []): ?DataResult
     {
         $params = [];
-        if (is_array($sql)) {
+        $sqlIsArray = is_array($sql);
+        if ($sqlIsArray) {
             $initialSQL = $sql[0];
-            $queryName = "tina4".rand(10000,99999).md5($sql[0]);
-            $params = array_merge([$this->getDbh(), $queryName], $sql);
+            $params = $sql;
             $sql = $sql[0];
         } else {
             $initialSQL = $sql;
@@ -39,8 +39,8 @@ class PostgresqlQuery extends DataConnection implements DataBaseQuery
             $sql .= " limit {$noOfRecords} offset {$offSet}";
         }
 
-        if (is_array($sql)) {
-            $recordCursor = pg_query_params(...$params);
+        if ($sqlIsArray) {
+            $recordCursor = pg_query_params($this->getDbh(), $sql, array_slice($params, 1));
         } else {
             $recordCursor = pg_query($this->getDbh(), $sql);
         }

--- a/Tina4/PostgresqlQuery.php
+++ b/Tina4/PostgresqlQuery.php
@@ -48,6 +48,7 @@ class PostgresqlQuery extends DataConnection implements DataBaseQuery
         $records = null;
         while ($record = pg_fetch_assoc($recordCursor)) {
             $record = (new PostgresqlBlobHandler($this->getConnection()))->decodeBlobs($record);
+            $record = $this->castRowValues($record, $recordCursor);
             $records[] = (new DataRecord(
                 $record,
                 $fieldMapping,
@@ -93,5 +94,35 @@ class PostgresqlQuery extends DataConnection implements DataBaseQuery
         $error = $this->getConnection()->error();
 
         return (new DataResult($records, $fields, $resultCount["COUNT_RECORDS"], $offSet, $error));
+    }
+
+    /**
+     * Casts PostgreSQL string values returned by pg_fetch_assoc to their native PHP types
+     * based on the column type reported by pg_field_type().
+     * @param array $row A single row from pg_fetch_assoc
+     * @param resource $cursor The PostgreSQL result cursor
+     * @return array Row with integer, float and boolean values properly typed
+     */
+    private function castRowValues(array $row, $cursor): array
+    {
+        $integerTypes = ['int2', 'int4', 'int8', 'oid'];
+        $floatTypes   = ['float4', 'float8', 'numeric'];
+        $fid = 0;
+        foreach ($row as $fieldName => $value) {
+            if ($value === null) {
+                $fid++;
+                continue;
+            }
+            $pgType = pg_field_type($cursor, $fid);
+            if (in_array($pgType, $integerTypes, true)) {
+                $row[$fieldName] = (int) $value;
+            } elseif (in_array($pgType, $floatTypes, true)) {
+                $row[$fieldName] = (float) $value;
+            } elseif ($pgType === 'bool') {
+                $row[$fieldName] = ($value === 't');
+            }
+            $fid++;
+        }
+        return $row;
     }
 }


### PR DESCRIPTION
Fix for this error as a result of the array spread: pg_query(): Query failed: ERROR: there is no parameter $1 LINE 2: values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$... ^ in /home/api_staging/public_html/vendor/tina4stack/tina4php-postgresql/Tina4/PostgresqlQuery.php (45)